### PR TITLE
pull in all groups at once, classes pulling in wrong fixed on classshow

### DIFF
--- a/backend/models/choice/index.js
+++ b/backend/models/choice/index.js
@@ -52,6 +52,18 @@ export async function getChoicesByQuestion(question_id) {
   );
 }
 
+export async function getChoicesByGroupId(group_id) {
+  const params = { group_id };
+  return await sqlExe.executeCommand(
+    `
+    SELECT c.id, c.answer, c.is_correct, c.created_at, gq.question_id, gq.group_id FROM choices c 
+    JOIN question_choice qc ON qc.choice_id = c.id
+    JOIN group_question gq ON qc.question_id = gq.question_id AND gq.group_id = :group_id
+`,
+    params
+  );
+}
+
 export async function addChoiceToQuestion( // NOT TESTED TODO
   user_id,
   question_id,

--- a/backend/routes/choice/index.js
+++ b/backend/routes/choice/index.js
@@ -7,6 +7,7 @@ import {
   postChoice,
   upsertCurrentChoice,
   getCurrentChoicesByGroupIdAndType,
+  getChoicesByGroupId,
 } from "#models/choice/index.js";
 import express, { Router } from "express";
 const router = Router();
@@ -69,7 +70,18 @@ router.get("/:question_id", isAuthenticated, async function (req, res) {
     res.status(200).json(result);
   } catch (error) {
     res.status(500).json({
-      message: `failed to get question by topic id ${req.params.question_id}`,
+      message: `failed to get choice by question id ${req.params.question_id}`,
+    });
+  }
+});
+
+router.get("/group/:group_id", isAuthenticated, async function (req, res) {
+  try {
+    const result = await getChoicesByGroupId(req.params.group_id);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(500).json({
+      message: `failed to get question by group id ${req.params.group_id}`,
     });
   }
 });

--- a/frontend/src/app/class/ClassShow.jsx
+++ b/frontend/src/app/class/ClassShow.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useParams } from 'react-router-dom';
 import { Container, Segment, Header, Button, Icon, Grid, Divider, Popup } from 'semantic-ui-react';
-import { selectClassStateByName } from './classSlice';
-import { changeNavbarPage } from '@components/navbar/navbarSlice';
+import { changeNavbarPage, selectNavbarState } from '@components/navbar/navbarSlice';
+import { selectArrayOfStateById } from '@utils/functions';
 
 export default function ClassShow() {
   const dispatch = useDispatch();
-  const { class_name: name } = useParams();
-  const { classes: curClass } = useSelector(selectClassStateByName(name));
+  const { classId } = useSelector(selectNavbarState).navbar;
+  const curClass = useSelector(selectArrayOfStateById('app.class.classes', 'id', classId))?.[0];
 
   if (!curClass) return null;
 
@@ -40,7 +39,12 @@ export default function ClassShow() {
 
         <Grid centered stackable columns={2}>
           <Grid.Column textAlign='center'>
-            <Button size='large' onClick={() => dispatch(changeNavbarPage('exam'))}>
+            <Button
+              size='large'
+              onClick={() => {
+                dispatch(changeNavbarPage('exam'));
+              }}
+            >
               <Icon name='list' />
               Study by Exam
             </Button>

--- a/frontend/src/app/class/question/QuestionChoices.jsx
+++ b/frontend/src/app/class/question/QuestionChoices.jsx
@@ -16,16 +16,12 @@ export default function QuestionChoices({ selectedQuestion }) {
   const [showAnswers, setShowAnswers] = useState(false);
 
   // give choices a random order TODO LET THE USER DO THIS.
-      choices = randomizeArray(choices, 1234);
+  choices = randomizeArray(choices, 1234);
 
   // navbar does not do this
   useEffect(() => {
     setShowAnswers(false);
-    if ((choices?.length == 0 || choices === null) && selectedQuestion) {
-      // testable
-      dispatch(getChoicesByQuestion(selectedQuestion.id));
-    }
-  }, [selectedQuestion]); // if selected question changes get the new choices only if I dont already have them pulled in.
+  }, [selectedQuestion]);
 
   return (
     <Segment loading={loading}>

--- a/frontend/src/app/class/question/choices/choicesSlice.js
+++ b/frontend/src/app/class/question/choices/choicesSlice.js
@@ -1,5 +1,6 @@
 import { standardApiCall } from '@utils/api';
 import { updateArrWithNewVals } from '@utils/functions';
+import { createSelector } from 'reselect';
 
 const GET_CHOICES_BY_Q = 'app/class/question/choices/GET_CHOICES_BY_Q';
 
@@ -34,6 +35,10 @@ export function getChoicesByQuestion(question_id) {
   return standardApiCall('get', `/api/choice/${question_id}`, null, GET_CHOICES_BY_Q, 'QuestionChoices');
 }
 
+export function getChoicesByGroup(group_id) {
+  return standardApiCall('get', `/api/choice/group/${group_id}`, null, GET_CHOICES_BY_Q, 'QuestionChoices'); //yes I know its same does not matter
+}
+
 const DEFAULT_STATE = {
   choices: null,
 };
@@ -46,3 +51,10 @@ export default function choicesReducer(state = DEFAULT_STATE, action) {
       return state;
   }
 }
+
+export const selectChoicesState = createSelector(
+  (state) => state,
+  function (state) {
+    return { choices: state.app.choices.choices };
+  },
+);

--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -28,6 +28,8 @@ import { selectQuestionState, getQuestionsByGroupId } from '@src/app/class/quest
 import { getExamsByClassId, selectExamsState } from '@src/app/class/group/exam/examSlice.js';
 import { replaceP20WithSpace } from '../../../../shared/globalFuncs';
 import { selectSchoolState, getSchools } from '@src/app/class/school/schoolSlice';
+import { selectChoicesState } from '@src/app/class/question/choices/choicesSlice';
+import { getChoicesByGroup } from '@src/app/class/question/choices/choicesSlice';
 
 export function examFetchLogic(dispatch, classId, className, exams, curGroupName, schoolName, schoolId) {
   console.count('exam');
@@ -105,6 +107,17 @@ export function questionFetchLogic(dispatch, questions, groupId, curGroupName, c
   }
 }
 
+export function choicesFetchLogic(dispatch, groupName, groupId, choices) {
+  console.count('choices');
+  if (groupName && groupId) {
+    // TODO CHECK FOR LOADING ON ALL OF THESE AS WELL
+    const do_i_alr_have_choices = findNeedleInArrayOfObjectsLINEAR(choices, 'group_id', groupId, 'id');
+    if (!do_i_alr_have_choices) {
+      dispatch(getChoicesByGroup(groupId));
+    }
+  }
+}
+
 export default function Navbar() {
   const location = useLocation();
   const { questions } = useSelector(selectQuestionState);
@@ -119,6 +132,7 @@ export default function Navbar() {
   const [sidebarOpened, setSidebarOpened] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const schools = useSelector(selectSchoolState).schools;
+  const choices = useSelector(selectChoicesState).choices;
 
   const { className, classId, groupName, groupId, questionId, schoolName, groupType, schoolId } =
     useSelector(selectNavbarState).navbar;
@@ -176,6 +190,9 @@ export default function Navbar() {
       }
       if (activePage?.includes('question')) {
         questionFetchLogic(dispatch, questions, groupId, urlArr[5], urlArr[4], urlArr[7]);
+      }
+      if (activePage?.includes('question')) {
+        choicesFetchLogic(dispatch, groupName, groupId, choices);
       }
     }
   }, [activePage, classId, className, exams, topics, groupId, groupName, groupType, classes, schoolName, schoolId]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new API endpoint to retrieve choices based on group ID.
	- Enhanced the `ClassShow` component to fetch class data using the updated navbar state.
	- Added functionality in the `Navbar` to fetch choices when relevant pages are accessed.

- **Bug Fixes**
	- Updated error messages in the choices retrieval endpoint for clarity.

- **Refactor**
	- Streamlined choice handling in the `QuestionChoices` component.

- **Documentation**
	- Improved state management and data fetching logic across several components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->